### PR TITLE
Persist game data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,10 @@ import { Leaderboard } from './components/Leaderboard';
 import { EventFeed } from './components/EventFeed';
 import { AddEventForm } from './components/AddEventForm';
 import { RenamePlayerForm } from './components/DeletePlayerForm';
+import { DataManager } from './components/DataManager';
+import { SaveStatus } from './components/SaveStatus';
+import { usePersistentState } from './hooks/usePersistentState';
+import { loadPlayers, savePlayers, loadLoggedEvents, saveLoggedEvents, loadLifeEvents, saveLifeEvents } from './utils/storage';
 
 // Initial state for demonstration purposes
 const INITIAL_PLAYERS: Player[] = [
@@ -54,9 +58,27 @@ const INITIAL_EVENTS: LoggedEvent[] = [
 ]
 
 export default function App() {
-  const [players, setPlayers] = useState<Player[]>(INITIAL_PLAYERS);
-  const [loggedEvents, setLoggedEvents] = useState<LoggedEvent[]>(INITIAL_EVENTS);
-  const [lifeEvents, setLifeEvents] = useState<EventDefinition[]>(LIFE_EVENTS);
+  // Use persistent state that automatically saves to localStorage
+  const [players, setPlayers] = usePersistentState(
+    'players',
+    INITIAL_PLAYERS,
+    savePlayers,
+    loadPlayers
+  );
+  
+  const [loggedEvents, setLoggedEvents] = usePersistentState(
+    'loggedEvents',
+    INITIAL_EVENTS,
+    saveLoggedEvents,
+    loadLoggedEvents
+  );
+  
+  const [lifeEvents, setLifeEvents] = usePersistentState(
+    'lifeEvents',
+    LIFE_EVENTS,
+    saveLifeEvents,
+    loadLifeEvents
+  );
 
   const familyMembers = useMemo(() => {
     return players.flatMap(p => p.members.map(m => ({ ...m, playerName: p.name, playerId: p.id })));
@@ -166,6 +188,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-slate-900 text-gray-200 font-sans p-4 sm:p-6 lg:p-8">
+      <SaveStatus />
       <div className="max-w-7xl mx-auto">
         <Header />
 
@@ -189,6 +212,14 @@ export default function App() {
                     <AddEventForm onAddEvent={addEvent} />
                 </div>
             </div>
+
+            {/* Data Management */}
+            <DataManager 
+              onDataImported={() => {
+                // Force reload to pick up imported data
+                window.location.reload();
+              }} 
+            />
           </div>
         </main>
       </div>

--- a/components/DataManager.tsx
+++ b/components/DataManager.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { exportGameData, importGameData, clearGameData, getStorageInfo } from '../utils/storage';
+
+interface DataManagerProps {
+  onDataImported?: () => void;
+}
+
+export function DataManager({ onDataImported }: DataManagerProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  
+  const storageInfo = getStorageInfo();
+
+  const handleExport = () => {
+    setIsExporting(true);
+    try {
+      const data = exportGameData();
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `fantasy-family-backup-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Export failed:', error);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string;
+        importGameData(content);
+        setImportError(null);
+        onDataImported?.();
+        // Reset file input
+        event.target.value = '';
+      } catch (error) {
+        setImportError(error instanceof Error ? error.message : 'Failed to import data');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleClearData = () => {
+    if (showClearConfirm) {
+      clearGameData();
+      setShowClearConfirm(false);
+      window.location.reload(); // Reload to reset state
+    } else {
+      setShowClearConfirm(true);
+    }
+  };
+
+  return (
+    <div className="bg-slate-800 p-6 rounded-xl shadow-lg">
+      <h2 className="text-2xl font-bold text-cyan-400 mb-4">Data Management</h2>
+      
+      {storageInfo.hasData && storageInfo.lastSaved && (
+        <div className="mb-4 text-sm text-gray-400">
+          Last saved: {new Date(storageInfo.lastSaved).toLocaleString()}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {/* Export Data */}
+        <div>
+          <button
+            onClick={handleExport}
+            disabled={isExporting}
+            className="w-full bg-green-600 hover:bg-green-700 disabled:bg-gray-600 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            {isExporting ? 'Exporting...' : 'Export Backup'}
+          </button>
+          <p className="text-xs text-gray-400 mt-1">
+            Download your game data as a JSON file for backup
+          </p>
+        </div>
+
+        {/* Import Data */}
+        <div>
+          <label className="block">
+            <input
+              type="file"
+              accept=".json"
+              onChange={handleImport}
+              className="hidden"
+            />
+            <span className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg transition-colors cursor-pointer block text-center">
+              Import Backup
+            </span>
+          </label>
+          <p className="text-xs text-gray-400 mt-1">
+            Restore game data from a backup file
+          </p>
+          {importError && (
+            <p className="text-red-400 text-xs mt-1">{importError}</p>
+          )}
+        </div>
+
+        {/* Clear Data */}
+        <div>
+          <button
+            onClick={handleClearData}
+            className={`w-full px-4 py-2 rounded-lg transition-colors ${
+              showClearConfirm
+                ? 'bg-red-600 hover:bg-red-700 text-white'
+                : 'bg-gray-600 hover:bg-gray-700 text-white'
+            }`}
+          >
+            {showClearConfirm ? 'Click Again to Confirm' : 'Clear All Data'}
+          </button>
+          <p className="text-xs text-gray-400 mt-1">
+            {showClearConfirm 
+              ? 'This will permanently delete all game data!'
+              : 'Reset the game and remove all saved data'
+            }
+          </p>
+          {showClearConfirm && (
+            <button
+              onClick={() => setShowClearConfirm(false)}
+              className="w-full mt-2 bg-gray-600 hover:bg-gray-700 text-white px-4 py-1 rounded-lg text-sm transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/SaveStatus.tsx
+++ b/components/SaveStatus.tsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+import { getStorageInfo } from '../utils/storage';
+
+export function SaveStatus() {
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // Check for updates every second
+    const interval = setInterval(() => {
+      const info = getStorageInfo();
+      if (info.lastSaved && info.lastSaved !== lastSaved) {
+        setLastSaved(info.lastSaved);
+        setIsVisible(true);
+        
+        // Hide after 3 seconds
+        setTimeout(() => setIsVisible(false), 3000);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [lastSaved]);
+
+  if (!isVisible || !lastSaved) return null;
+
+  const timeAgo = new Date(lastSaved).toLocaleTimeString();
+
+  return (
+    <div className="fixed top-4 right-4 bg-green-600 text-white px-3 py-2 rounded-lg shadow-lg transition-opacity duration-300 text-sm z-50">
+      <div className="flex items-center gap-2">
+        <div className="w-2 h-2 bg-white rounded-full animate-pulse"></div>
+        <span>Saved at {timeAgo}</span>
+      </div>
+    </div>
+  );
+}

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Custom hook that automatically persists state to localStorage
+ */
+export function usePersistentState<T>(
+  key: string,
+  initialValue: T,
+  saveFunction: (value: T) => void,
+  loadFunction: (fallback: T) => T
+) {
+  // Load initial state from localStorage or use provided initial value
+  const [state, setState] = useState<T>(() => {
+    return loadFunction(initialValue);
+  });
+
+  // Auto-save whenever state changes
+  useEffect(() => {
+    saveFunction(state);
+  }, [state, saveFunction]);
+
+  // Provide a way to reset to initial value
+  const resetState = useCallback(() => {
+    setState(initialValue);
+  }, [initialValue]);
+
+  return [state, setState, resetState] as const;
+}
+
+/**
+ * Debounced version for frequently changing data
+ */
+export function useDebouncedPersistentState<T>(
+  key: string,
+  initialValue: T,
+  saveFunction: (value: T) => void,
+  loadFunction: (fallback: T) => T,
+  delay: number = 500
+) {
+  const [state, setState] = useState<T>(() => {
+    return loadFunction(initialValue);
+  });
+
+  // Debounced save effect
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      saveFunction(state);
+    }, delay);
+
+    return () => clearTimeout(timeoutId);
+  }, [state, saveFunction, delay]);
+
+  const resetState = useCallback(() => {
+    setState(initialValue);
+  }, [initialValue]);
+
+  return [state, setState, resetState] as const;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
+        "@types/react": "^19.1.12",
+        "@types/react-dom": "^19.1.9",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
       }
@@ -769,6 +771,33 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
+      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.9",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,190 @@
+import { Player, LoggedEvent, EventDefinition } from '../types';
+
+// Storage keys
+const STORAGE_KEYS = {
+  PLAYERS: 'fantasy-family-players',
+  EVENTS: 'fantasy-family-events',
+  LIFE_EVENTS: 'fantasy-family-life-events',
+  LAST_SAVED: 'fantasy-family-last-saved',
+} as const;
+
+// Storage interface for type safety
+export interface GameData {
+  players: Player[];
+  loggedEvents: LoggedEvent[];
+  lifeEvents: EventDefinition[];
+  lastSaved: string;
+}
+
+/**
+ * Safely parse JSON with fallback
+ */
+function safeJsonParse<T>(jsonString: string | null, fallback: T): T {
+  if (!jsonString) return fallback;
+  
+  try {
+    const parsed = JSON.parse(jsonString);
+    // Convert timestamp strings back to Date objects for LoggedEvent
+    if (Array.isArray(parsed)) {
+      return parsed.map((item: any) => {
+        if (item.timestamp && typeof item.timestamp === 'string') {
+          return { ...item, timestamp: new Date(item.timestamp) };
+        }
+        return item;
+      }) as T;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored data:', error);
+    return fallback;
+  }
+}
+
+/**
+ * Load players from localStorage
+ */
+export function loadPlayers(fallback: Player[] = []): Player[] {
+  const stored = localStorage.getItem(STORAGE_KEYS.PLAYERS);
+  return safeJsonParse(stored, fallback);
+}
+
+/**
+ * Save players to localStorage
+ */
+export function savePlayers(players: Player[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.PLAYERS, JSON.stringify(players));
+    localStorage.setItem(STORAGE_KEYS.LAST_SAVED, new Date().toISOString());
+  } catch (error) {
+    console.error('Failed to save players:', error);
+  }
+}
+
+/**
+ * Load logged events from localStorage
+ */
+export function loadLoggedEvents(fallback: LoggedEvent[] = []): LoggedEvent[] {
+  const stored = localStorage.getItem(STORAGE_KEYS.EVENTS);
+  return safeJsonParse(stored, fallback);
+}
+
+/**
+ * Save logged events to localStorage
+ */
+export function saveLoggedEvents(events: LoggedEvent[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.EVENTS, JSON.stringify(events));
+    localStorage.setItem(STORAGE_KEYS.LAST_SAVED, new Date().toISOString());
+  } catch (error) {
+    console.error('Failed to save events:', error);
+  }
+}
+
+/**
+ * Load life events from localStorage
+ */
+export function loadLifeEvents(fallback: EventDefinition[] = []): EventDefinition[] {
+  const stored = localStorage.getItem(STORAGE_KEYS.LIFE_EVENTS);
+  return safeJsonParse(stored, fallback);
+}
+
+/**
+ * Save life events to localStorage
+ */
+export function saveLifeEvents(events: EventDefinition[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEYS.LIFE_EVENTS, JSON.stringify(events));
+    localStorage.setItem(STORAGE_KEYS.LAST_SAVED, new Date().toISOString());
+  } catch (error) {
+    console.error('Failed to save life events:', error);
+  }
+}
+
+/**
+ * Load all game data at once
+ */
+export function loadGameData(fallbackData: Partial<GameData> = {}): GameData {
+  const players = loadPlayers(fallbackData.players);
+  const loggedEvents = loadLoggedEvents(fallbackData.loggedEvents);
+  const lifeEvents = loadLifeEvents(fallbackData.lifeEvents);
+  const lastSaved = localStorage.getItem(STORAGE_KEYS.LAST_SAVED) || new Date().toISOString();
+
+  return {
+    players,
+    loggedEvents,
+    lifeEvents,
+    lastSaved,
+  };
+}
+
+/**
+ * Save all game data at once
+ */
+export function saveGameData(data: Omit<GameData, 'lastSaved'>): void {
+  savePlayers(data.players);
+  saveLoggedEvents(data.loggedEvents);
+  saveLifeEvents(data.lifeEvents);
+}
+
+/**
+ * Export game data as JSON for backup
+ */
+export function exportGameData(): string {
+  const data = loadGameData();
+  return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Import game data from JSON backup
+ */
+export function importGameData(jsonData: string): GameData {
+  try {
+    const data = JSON.parse(jsonData) as GameData;
+    
+    // Validate the data structure
+    if (!Array.isArray(data.players) || !Array.isArray(data.loggedEvents) || !Array.isArray(data.lifeEvents)) {
+      throw new Error('Invalid data structure');
+    }
+
+    // Convert timestamp strings back to Date objects
+    const processedData = {
+      ...data,
+      loggedEvents: data.loggedEvents.map(event => ({
+        ...event,
+        timestamp: new Date(event.timestamp),
+      })),
+    };
+
+    saveGameData(processedData);
+    return processedData;
+  } catch (error) {
+    console.error('Failed to import game data:', error);
+    throw new Error('Invalid backup file format');
+  }
+}
+
+/**
+ * Clear all stored data
+ */
+export function clearGameData(): void {
+  Object.values(STORAGE_KEYS).forEach(key => {
+    localStorage.removeItem(key);
+  });
+}
+
+/**
+ * Check if there's any stored data
+ */
+export function hasStoredData(): boolean {
+  return Object.values(STORAGE_KEYS).some(key => localStorage.getItem(key) !== null);
+}
+
+/**
+ * Get storage usage information
+ */
+export function getStorageInfo(): { lastSaved: string | null; hasData: boolean } {
+  return {
+    lastSaved: localStorage.getItem(STORAGE_KEYS.LAST_SAVED),
+    hasData: hasStoredData(),
+  };
+}


### PR DESCRIPTION
Add client-side data persistence with `localStorage` to automatically save and load game state, preventing data loss on refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2e5e0b5-5da9-44f7-8f29-8d918fa7e259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2e5e0b5-5da9-44f7-8f29-8d918fa7e259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

