### PR TITLE
Add player deletion capability

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,8 @@ import { LogEventForm } from './components/LogEventForm';
 import { Leaderboard } from './components/Leaderboard';
 import { EventFeed } from './components/EventFeed';
 import { AddEventForm } from './components/AddEventForm';
-import { RenamePlayerForm } from './components/DeletePlayerForm';
+import { RenamePlayerForm } from './components/RenamePlayerForm';
+import { DeletePlayerForm } from './components/DeletePlayerForm';
 import {
   loadPlayers,
   loadLoggedEvents,
@@ -115,6 +116,21 @@ export default function App() {
     );
   };
 
+  const deletePlayer = (playerId: string) => {
+    const playerToDelete = players.find(p => p.id === playerId);
+    if (!playerToDelete) return;
+
+    // Remove the player from the players array
+    setPlayers(currentPlayers => 
+      currentPlayers.filter(p => p.id !== playerId)
+    );
+
+    // Remove all logged events associated with this player
+    setLoggedEvents(currentEvents =>
+      currentEvents.filter(e => e.playerName !== playerToDelete.name)
+    );
+  };
+
 
   const addMember = (playerId: string, memberName: string) => {
     if (memberName.trim() === '' || !playerId) return;
@@ -205,6 +221,7 @@ export default function App() {
                     <AddMemberForm players={players} onAddMember={addMember} />
                     <LogEventForm players={players} lifeEvents={lifeEvents} onLogEvent={logEvent} />
                     <RenamePlayerForm players={players} onRenamePlayer={renamePlayer} />
+                    <DeletePlayerForm players={players} onDeletePlayer={deletePlayer} />
                     <hr className="border-slate-700" />
                     <AddEventForm onAddEvent={addEvent} />
                 </div>

--- a/components/DeletePlayerForm.tsx
+++ b/components/DeletePlayerForm.tsx
@@ -1,66 +1,79 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Player } from '../types';
 
-interface RenamePlayerFormProps {
+interface DeletePlayerFormProps {
   players: Player[];
-  onRenamePlayer: (playerId: string, newName: string) => void;
+  onDeletePlayer: (playerId: string) => void;
 }
 
-export const RenamePlayerForm: React.FC<RenamePlayerFormProps> = ({ players, onRenamePlayer }) => {
+export const DeletePlayerForm: React.FC<DeletePlayerFormProps> = ({ players, onDeletePlayer }) => {
   const [selectedPlayerId, setSelectedPlayerId] = useState('');
-  const [newName, setNewName] = useState('');
+  const [confirmationName, setConfirmationName] = useState('');
 
-  useEffect(() => {
-    const selectedPlayer = players.find(p => p.id === selectedPlayerId);
-    if (selectedPlayer) {
-      setNewName(selectedPlayer.name);
-    } else {
-      setNewName('');
-    }
-  }, [selectedPlayerId, players]);
+  const selectedPlayer = players.find(p => p.id === selectedPlayerId);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!selectedPlayerId || !newName.trim()) return;
-    onRenamePlayer(selectedPlayerId, newName);
+    if (!selectedPlayerId || !selectedPlayer) return;
+    
+    // Require exact name match for confirmation
+    if (confirmationName.trim() !== selectedPlayer.name) {
+      alert('Player name does not match. Please type the exact player name to confirm deletion.');
+      return;
+    }
+    
+    onDeletePlayer(selectedPlayerId);
     setSelectedPlayerId('');
-    setNewName('');
+    setConfirmationName('');
   };
+
+  const isDeleteDisabled = !selectedPlayerId || !selectedPlayer || confirmationName.trim() !== selectedPlayer.name;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
-      <label htmlFor="renamePlayerSelect" className="block text-sm font-medium text-slate-300">
-        4. Rename Player
+      <label htmlFor="deletePlayerSelect" className="block text-sm font-medium text-red-400">
+        5. Delete Player
       </label>
-      <div className="flex flex-col sm:flex-row gap-2">
+      <div className="space-y-2">
         <select
-          id="renamePlayerSelect"
+          id="deletePlayerSelect"
           value={selectedPlayerId}
-          onChange={(e) => setSelectedPlayerId(e.target.value)}
-          className="flex-grow bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
+          onChange={(e) => {
+            setSelectedPlayerId(e.target.value);
+            setConfirmationName(''); // Reset confirmation when player changes
+          }}
+          className="w-full bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-red-500 focus:outline-none transition"
         >
-          <option value="">Select a Player...</option>
+          <option value="">Select a Player to Delete...</option>
           {players.map((player) => (
             <option key={player.id} value={player.id}>
-              {player.name}
+              {player.name} (Score: {player.score}, Members: {player.members.length})
             </option>
           ))}
         </select>
-        <input
-          type="text"
-          value={newName}
-          onChange={(e) => setNewName(e.target.value)}
-          placeholder="Enter new name"
-          className="flex-grow bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
-          disabled={!selectedPlayerId}
-        />
+        
+        {selectedPlayer && (
+          <div className="bg-red-900/20 border border-red-700 rounded-md p-3">
+            <p className="text-red-400 text-sm mb-2">
+              ⚠️ This will permanently delete <strong>{selectedPlayer.name}</strong> and all their {selectedPlayer.members.length} family member(s).
+            </p>
+            <input
+              type="text"
+              value={confirmationName}
+              onChange={(e) => setConfirmationName(e.target.value)}
+              placeholder={`Type "${selectedPlayer.name}" to confirm`}
+              className="w-full bg-slate-700 border border-red-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-red-500 focus:outline-none transition"
+            />
+          </div>
+        )}
       </div>
+      
       <button
         type="submit"
-        className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-md hover:bg-blue-700 transition-colors disabled:bg-slate-600 disabled:cursor-not-allowed"
-        disabled={!selectedPlayerId || !newName.trim()}
+        className="w-full bg-red-600 text-white font-bold py-2 px-4 rounded-md hover:bg-red-700 transition-colors disabled:bg-slate-600 disabled:cursor-not-allowed"
+        disabled={isDeleteDisabled}
       >
-        Rename Player
+        {selectedPlayer ? `Delete ${selectedPlayer.name}` : 'Delete Player'}
       </button>
     </form>
   );

--- a/components/RenamePlayerForm.tsx
+++ b/components/RenamePlayerForm.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import { Player } from '../types';
+
+interface RenamePlayerFormProps {
+  players: Player[];
+  onRenamePlayer: (playerId: string, newName: string) => void;
+}
+
+export const RenamePlayerForm: React.FC<RenamePlayerFormProps> = ({ players, onRenamePlayer }) => {
+  const [selectedPlayerId, setSelectedPlayerId] = useState('');
+  const [newName, setNewName] = useState('');
+
+  useEffect(() => {
+    const selectedPlayer = players.find(p => p.id === selectedPlayerId);
+    if (selectedPlayer) {
+      setNewName(selectedPlayer.name);
+    } else {
+      setNewName('');
+    }
+  }, [selectedPlayerId, players]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedPlayerId || !newName.trim()) return;
+    onRenamePlayer(selectedPlayerId, newName);
+    setSelectedPlayerId('');
+    setNewName('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <label htmlFor="renamePlayerSelect" className="block text-sm font-medium text-slate-300">
+        4. Rename Player
+      </label>
+      <div className="flex flex-col sm:flex-row gap-2">
+        <select
+          id="renamePlayerSelect"
+          value={selectedPlayerId}
+          onChange={(e) => setSelectedPlayerId(e.target.value)}
+          className="flex-grow bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
+        >
+          <option value="">Select a Player...</option>
+          {players.map((player) => (
+            <option key={player.id} value={player.id}>
+              {player.name}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Enter new name"
+          className="flex-grow bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
+          disabled={!selectedPlayerId}
+        />
+      </div>
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-md hover:bg-blue-700 transition-colors disabled:bg-slate-600 disabled:cursor-not-allowed"
+        disabled={!selectedPlayerId || !newName.trim()}
+      >
+        Rename Player
+      </button>
+    </form>
+  );
+};


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

## Summary by Sourcery

Add functionality to delete players with a confirmation step and extract the existing rename player form into its own component

New Features:
- Introduce DeletePlayerForm component to allow permanent removal of a player by typing their exact name for confirmation
- Implement deletePlayer handler in App to remove the selected player and all associated logged events

Enhancements:
- Refactor and extract the rename player form into a standalone RenamePlayerForm.tsx component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to delete players from the Commissioner’s Desk with a confirmation step (type the exact name).
  - Deleting a player also removes all of their logged events.
  - Introduced a Rename Player form with validation and state reset after completion.
  - Player select options now include helpful context (score and member count).

- UI/UX
  - Destructive delete styling with a red warning panel highlighting impact.
  - Improved placeholders and disabled controls until required inputs are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->