### PR TITLE
Implement player family member trading

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -153,6 +153,48 @@ export default function App() {
     setLifeEvents(currentEvents => [...currentEvents, newEvent]);
   };
 
+  const tradeMember = (memberId: string, toPlayerId: string) => {
+    if (!memberId || !toPlayerId) return;
+
+    let fromPlayer: Player | undefined;
+    let memberToTrade: FamilyMember | undefined;
+    for (const player of players) {
+      const member = player.members.find(m => m.id === memberId);
+      if (member) {
+        fromPlayer = player;
+        memberToTrade = member;
+        break;
+      }
+    }
+
+    if (!fromPlayer || !memberToTrade) return;
+    if (fromPlayer.id === toPlayerId) return;
+
+    const toPlayer = players.find(p => p.id === toPlayerId);
+    if (!toPlayer) return;
+
+    setPlayers(currentPlayers => currentPlayers.map(p => {
+      if (p.id === fromPlayer!.id) {
+        return { ...p, members: p.members.filter(m => m.id !== memberId) };
+      }
+      if (p.id === toPlayerId) {
+        return { ...p, members: [...p.members, memberToTrade!] };
+      }
+      return p;
+    }));
+
+    const tradeLog: LoggedEvent = {
+      id: crypto.randomUUID(),
+      memberName: memberToTrade.name,
+      playerName: `${fromPlayer.name} → ${toPlayer.name}`,
+      eventName: 'Member Traded',
+      points: 0,
+      timestamp: new Date(),
+      category: 'neutral',
+    };
+    setLoggedEvents(currentEvents => [tradeLog, ...currentEvents]);
+  };
+
   const logEvent = (memberId: string, eventId: string) => {
     const eventDefinition = lifeEvents.find(e => e.id === eventId);
     if (!eventDefinition) return;
@@ -214,6 +256,7 @@ export default function App() {
               onAddPlayer={addPlayer}
               onAddMember={addMember}
               onLogEvent={logEvent}
+              onTradeMember={tradeMember}
               onRenamePlayer={renamePlayer}
               onDeletePlayer={deletePlayer}
               onAddEvent={addEvent}

--- a/components/CommissionerDesk.tsx
+++ b/components/CommissionerDesk.tsx
@@ -6,6 +6,7 @@ import { LogEventForm } from './LogEventForm';
 import { RenamePlayerForm } from './RenamePlayerForm';
 import { DeletePlayerForm } from './DeletePlayerForm';
 import { AddEventForm } from './AddEventForm';
+import { TradeMemberForm } from './TradeMemberForm';
 
 interface CommissionerDeskProps {
   players: Player[];
@@ -13,6 +14,7 @@ interface CommissionerDeskProps {
   onAddPlayer: (name: string) => void;
   onAddMember: (playerId: string, memberName: string) => void;
   onLogEvent: (memberId: string, eventId: string) => void;
+  onTradeMember: (memberId: string, toPlayerId: string) => void;
   onRenamePlayer: (playerId: string, newName: string) => void;
   onDeletePlayer: (playerId: string) => void;
   onAddEvent: (name: string, points: number, category: EventCategory) => void;
@@ -24,6 +26,7 @@ export const CommissionerDesk: React.FC<CommissionerDeskProps> = ({
   onAddPlayer,
   onAddMember,
   onLogEvent,
+  onTradeMember,
   onRenamePlayer,
   onDeletePlayer,
   onAddEvent,
@@ -35,6 +38,7 @@ export const CommissionerDesk: React.FC<CommissionerDeskProps> = ({
         <div className="space-y-6">
           <AddPlayerForm onAddPlayer={onAddPlayer} />
           <AddMemberForm players={players} onAddMember={onAddMember} />
+          <TradeMemberForm players={players} onTradeMember={onTradeMember} />
           <LogEventForm players={players} lifeEvents={lifeEvents} onLogEvent={onLogEvent} />
           <RenamePlayerForm players={players} onRenamePlayer={onRenamePlayer} />
           <DeletePlayerForm players={players} onDeletePlayer={onDeletePlayer} />

--- a/components/TradeMemberForm.tsx
+++ b/components/TradeMemberForm.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo, useState } from 'react';
+import { Player } from '../types';
+
+interface TradeMemberFormProps {
+  players: Player[];
+  onTradeMember: (memberId: string, toPlayerId: string) => void;
+}
+
+export const TradeMemberForm: React.FC<TradeMemberFormProps> = ({ players, onTradeMember }) => {
+  const [selectedMemberId, setSelectedMemberId] = useState('');
+  const [selectedTargetPlayerId, setSelectedTargetPlayerId] = useState('');
+
+  const allMembers = useMemo(() => {
+    return players.flatMap(player => 
+      player.members.map(member => ({ ...member, ownerPlayerId: player.id, ownerPlayerName: player.name }))
+    );
+  }, [players]);
+
+  const ownerOfSelectedMemberId = useMemo(() => {
+    if (!selectedMemberId) return undefined;
+    return players.find(p => p.members.some(m => m.id === selectedMemberId));
+  }, [players, selectedMemberId]);
+
+  const eligibleTargetPlayers = useMemo(() => {
+    if (!ownerOfSelectedMemberId) return players;
+    return players.filter(p => p.id !== ownerOfSelectedMemberId.id);
+  }, [players, ownerOfSelectedMemberId]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedMemberId || !selectedTargetPlayerId) return;
+    onTradeMember(selectedMemberId, selectedTargetPlayerId);
+    setSelectedMemberId('');
+    setSelectedTargetPlayerId('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <label htmlFor="tradeMemberSelect" className="block text-sm font-medium text-slate-300">
+        4. Trade Family Member
+      </label>
+      <div className="flex flex-col gap-2">
+        <select
+          id="tradeMemberSelect"
+          value={selectedMemberId}
+          onChange={(e) => {
+            setSelectedMemberId(e.target.value);
+            setSelectedTargetPlayerId('');
+          }}
+          className="w-full bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
+        >
+          <option value="">Select Family Member...</option>
+          {allMembers.map((member) => (
+            <option key={member.id} value={member.id}>
+              {member.name} (Owned by {member.ownerPlayerName})
+            </option>
+          ))}
+        </select>
+
+        <select
+          id="tradeTargetPlayerSelect"
+          value={selectedTargetPlayerId}
+          onChange={(e) => setSelectedTargetPlayerId(e.target.value)}
+          className="w-full bg-slate-700 border border-slate-600 text-white rounded-md px-3 py-2 focus:ring-2 focus:ring-cyan-500 focus:outline-none transition"
+          disabled={!selectedMemberId}
+        >
+          <option value="">Select Destination Player...</option>
+          {eligibleTargetPlayers.map((player) => (
+            <option key={player.id} value={player.id}>
+              {player.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button
+        type="submit"
+        className="w-full bg-indigo-600 text-white font-bold py-2 px-4 rounded-md hover:bg-indigo-700 transition-colors disabled:bg-slate-600 disabled:cursor-not-allowed"
+        disabled={!selectedMemberId || !selectedTargetPlayerId}
+      >
+        Trade Member
+      </button>
+    </form>
+  );
+};
+


### PR DESCRIPTION
Add the ability for players to trade family members via a new form in the Commissioner Desk.

---
<a href="https://cursor.com/background-agent?bcId=bc-596dfd4a-92cf-4775-b598-9a04ff142a0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-596dfd4a-92cf-4775-b598-9a04ff142a0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Implement player family member trading functionality by introducing a TradeMemberForm UI, wiring an onTradeMember callback in Commissioner Desk, and updating App state and event logs to handle member transfers.

New Features:
- Allow players to trade family members via a new form in the Commissioner Desk

Enhancements:
- Implement tradeMember handler in App.tsx to update player rosters and log trade events
- Add TradeMemberForm component and wire onTradeMember prop through CommissionerDesk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade a family member between players directly from the Commissioner Desk.
  * Guided form with member and destination player selectors; submit enabled only when valid.
  * Prevents invalid actions (e.g., trading to the same owner) and handles missing selections gracefully.
  * Automatically logs each trade in the activity log with neutral points and a timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->