### PR TITLE
Fix vite not found on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "npm run build && node server.js",
+    "start": "node server.js",
     "heroku-postbuild": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Fix "vite: not found" error on Heroku by modifying the `start` script to only run the Node server.

The previous `start` script attempted to run `vite build` at runtime, but Vite is a dev dependency and not available in the production environment on Heroku, leading to a "sh: 1: vite: not found" error. This change ensures the build step is handled by `heroku-postbuild` during slug compilation, and the `start` script only launches the pre-built application.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5c68c2d-e013-465e-9820-9031f94505fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5c68c2d-e013-465e-9820-9031f94505fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

