### PR TITLE
Persist application state across sessions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,16 +24,38 @@ heroku config:set GEMINI_API_KEY=your_gemini_api_key_here
 
 1. Make sure you have the Heroku CLI installed
 2. Create a new Heroku app or use existing one
-3. Set the environment variable:
+3. Provision Postgres and set environment variables:
 
    ```bash
+   heroku addons:create heroku-postgresql:mini
    heroku config:set GEMINI_API_KEY=your_actual_api_key
    ```
 
-4. Deploy:
+4. (Optional) Import initial state
+
+   If you want to seed initial app state, you can open the app locally, make changes, and then it will persist to Heroku once deployed. Alternatively, you can insert JSON directly:
+
+   ```bash
+   heroku pg:psql --app <your-app-name> <<'SQL'
+   CREATE TABLE IF NOT EXISTS app_state (
+     id TEXT PRIMARY KEY,
+     data JSONB NOT NULL,
+     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+   );
+   INSERT INTO app_state (id, data) VALUES ('default', '{"players":[],"events":[],"lifeEvents":[]}')
+   ON CONFLICT (id) DO NOTHING;
+   SQL
+   ```
+
+5. Deploy:
 
    ```bash
    git push heroku main
    ```
 
 The app will automatically build and start using the configuration in `Procfile`.
+
+### Notes
+
+- The server exposes `GET /api/state` and `PUT /api/state` to load and persist the entire application state.
+- In local development without `DATABASE_URL`, the server falls back to in-memory state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vitejs/plugin-react": "^4.2.1",
         "express": "^4.18.2",
+        "pg": "^8.12.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "terser": "^5.24.0",
@@ -1978,6 +1979,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2022,6 +2112,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -2347,6 +2476,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2561,6 +2699,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "express": "^4.18.2",
+    "pg": "^8.12.0",
     "terser": "^5.24.0",
     "@vitejs/plugin-react": "^4.2.1",
     "vite": "^6.2.0",

--- a/server.js
+++ b/server.js
@@ -1,12 +1,85 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import pg from 'pg';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// Parse JSON bodies
+app.use(express.json({ limit: '1mb' }));
+
+// Setup Postgres connection
+const { Pool } = pg;
+const hasDatabaseUrl = Boolean(process.env.DATABASE_URL);
+const pool = hasDatabaseUrl
+  ? new Pool({
+      connectionString: process.env.DATABASE_URL,
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+    })
+  : null;
+
+// In-memory fallback for local development when no DATABASE_URL is set
+let memoryState = null;
+
+// Ensure table exists
+async function ensureTable() {
+  if (!pool) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS app_state (
+      id TEXT PRIMARY KEY,
+      data JSONB NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+}
+
+ensureTable().catch((err) => {
+  console.error('Failed to ensure tables exist', err);
+});
+
+// API routes for getting/saving entire app state
+app.get('/api/state', async (req, res) => {
+  try {
+    if (!pool) {
+      if (!memoryState) return res.status(404).json({ error: 'No state found' });
+      return res.json(memoryState);
+    }
+    const result = await pool.query('SELECT data FROM app_state WHERE id = $1', ['default']);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'No state found' });
+    }
+    res.json(result.rows[0].data);
+  } catch (err) {
+    console.error('GET /api/state error', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+app.put('/api/state', async (req, res) => {
+  try {
+    const data = req.body;
+    if (!data || typeof data !== 'object') {
+      return res.status(400).json({ error: 'Invalid body' });
+    }
+    if (!pool) {
+      memoryState = data;
+      return res.status(204).end();
+    }
+    await pool.query(
+      `INSERT INTO app_state (id, data) VALUES ($1, $2)
+       ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, updated_at = NOW()`,
+      ['default', data]
+    );
+    res.status(204).end();
+  } catch (err) {
+    console.error('PUT /api/state error', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 // Serve static files from the dist directory
 app.use(express.static(path.join(__dirname, 'dist')));

--- a/storage.ts
+++ b/storage.ts
@@ -1,54 +1,50 @@
 import { Player, LoggedEvent, EventDefinition } from './types';
 
-const STORAGE_KEYS = {
-  players: 'ff_players',
-  events: 'ff_events',
-  lifeEvents: 'ff_life_events',
-} as const;
+export interface AppStatePayload {
+  players: Player[];
+  events: Array<Omit<LoggedEvent, 'timestamp'> & { timestamp: string }>;
+  lifeEvents: EventDefinition[];
+}
 
-function safeParseJson<T>(value: string | null): T | undefined {
-  if (!value) return undefined;
+export interface AppState {
+  players: Player[];
+  events: LoggedEvent[];
+  lifeEvents: EventDefinition[];
+}
+
+export async function loadState(): Promise<AppState | undefined> {
   try {
-    return JSON.parse(value) as T;
+    const response = await fetch('/api/state', { method: 'GET' });
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as AppStatePayload;
+    const events: LoggedEvent[] = (data.events || []).map((e) => ({
+      ...e,
+      timestamp: new Date(e.timestamp),
+    }));
+    return {
+      players: data.players || [],
+      events,
+      lifeEvents: data.lifeEvents || [],
+    };
   } catch {
     return undefined;
   }
 }
 
-export function loadPlayers(): Player[] | undefined {
-  return safeParseJson<Player[]>(window.localStorage.getItem(STORAGE_KEYS.players));
-}
-
-export function savePlayers(players: Player[]): void {
-  window.localStorage.setItem(STORAGE_KEYS.players, JSON.stringify(players));
-}
-
-export function loadLoggedEvents(): LoggedEvent[] | undefined {
-  const raw = safeParseJson<Array<Omit<LoggedEvent, 'timestamp'> & { timestamp: string | number }>>(
-    window.localStorage.getItem(STORAGE_KEYS.events)
-  );
-  if (!raw) return undefined;
-  return raw.map((e) => ({
-    ...e,
-    timestamp: new Date(e.timestamp),
-  }));
-}
-
-export function saveLoggedEvents(events: LoggedEvent[]): void {
-  window.localStorage.setItem(STORAGE_KEYS.events, JSON.stringify(events));
-}
-
-export function loadLifeEvents(): EventDefinition[] | undefined {
-  return safeParseJson<EventDefinition[]>(window.localStorage.getItem(STORAGE_KEYS.lifeEvents));
-}
-
-export function saveLifeEvents(events: EventDefinition[]): void {
-  window.localStorage.setItem(STORAGE_KEYS.lifeEvents, JSON.stringify(events));
-}
-
-export function clearAllStoredData(): void {
-  window.localStorage.removeItem(STORAGE_KEYS.players);
-  window.localStorage.removeItem(STORAGE_KEYS.events);
-  window.localStorage.removeItem(STORAGE_KEYS.lifeEvents);
+export async function saveState(
+  players: Player[],
+  events: LoggedEvent[],
+  lifeEvents: EventDefinition[]
+): Promise<void> {
+  const payload: AppStatePayload = {
+    players,
+    events: events.map((e) => ({ ...e, timestamp: e.timestamp.toISOString() })),
+    lifeEvents,
+  };
+  await fetch('/api/state', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
 }
 


### PR DESCRIPTION
Implement a shared Postgres-backed API for application state to ensure persistent updates across all devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc25ecd5-0c2d-414f-8a1a-b3f686dbfa70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc25ecd5-0c2d-414f-8a1a-b3f686dbfa70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Introduce a shared Postgres-backed API for persisting and retrieving the entire application state, replacing localStorage-based storage with server-side persistence and providing seamless hydration and updates across sessions and devices.

New Features:
- Add GET and PUT /api/state endpoints for loading and saving the full application state with PostgreSQL persistence and an in-memory fallback
- Introduce loadState and saveState in the client storage module to fetch and persist AppState via the new API

Enhancements:
- Replace all localStorage-based load/save functions with remote state hydration on mount and automatic state syncing after initial hydration in App.tsx

Build:
- Add pg dependency and initialize a PostgreSQL pool with automatic table creation for app_state

Documentation:
- Update deployment guide to include provisioning the Heroku Postgres addon, seeding initial state, and documenting the /api/state endpoints